### PR TITLE
refactor: unify password and pin generation logic #20

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5,33 +5,32 @@ use predicates::prelude::*;
 fn test_cli_help() {
     let mut cmd = cargo_bin_cmd!("signum");
     cmd.arg("--help")
-       .assert()
-       .success()
-       .stdout(predicate::str::contains("Usage: signum"));
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Usage: signum"));
 }
 
 #[test]
 fn test_cli_remove_chars_integration() {
     let mut cmd = cargo_bin_cmd!("signum");
     let all_possible = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789)-(*&^%$#@!~";
-    cmd.arg("100").arg("-r").arg(all_possible)
-       .assert()
-       .success()
-       .stdout(predicate::str::contains("!!!_POOL_EMPTY_!!!"));
+    cmd.arg("100")
+        .arg("-r")
+        .arg(all_possible)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("!!!_POOL_EMPTY_!!!"));
 }
 
 #[test]
 fn test_cli_ambiguous_flag() {
     let mut cmd = cargo_bin_cmd!("signum");
-    
+
     // Generate 10 passwords of length 50 with the -B flag
-    // We use -B to avoid ambiguous characters (0, 1, l, I, etc.)
-    cmd.arg("50")
-       .arg("10")
-       .arg("-B")
-       .assert()
-       .success()
-       .stdout(predicate::str::is_match(r"^[a-km-zA-HJ-NP-Z2-9\W\s]+$").unwrap());
+    // -B to avoid ambiguous characters (0, 1, l, I)
+    cmd.arg("50").arg("10").arg("-B").assert().success().stdout(
+        predicate::str::is_match(r"^[a-km-zA-HJ-NP-Z2-9\W\s]+$").unwrap(),
+    );
 }
 
 #[test]
@@ -40,11 +39,11 @@ fn test_cli_no_capitalize_flag() {
 
     // Generate 20 passwords of length 100 with the -A flag
     cmd.arg("100")
-       .arg("20")
-       .arg("-A")
-       .assert()
-       .success()
-       .stdout(predicate::str::is_match(r"^[^A-Z]+$").unwrap());
+        .arg("20")
+        .arg("-A")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"^[^A-Z]+$").unwrap());
 }
 
 #[test]
@@ -53,9 +52,23 @@ fn test_cli_digital_only_flag() {
 
     // Generate 10 passwords of length 20 using the -d flag
     cmd.arg("20")
-       .arg("10")
-       .arg("-d")
-       .assert()
-       .success()
-       .stdout(predicate::str::is_match(r"^[0-9\s]+$").unwrap());
+        .arg("10")
+        .arg("-d")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"^[0-9\s]+$").unwrap());
+}
+
+#[test]
+fn test_cli_digital_ignores_removal_for_now() {
+    let mut cmd = cargo_bin_cmd!("signum");
+
+    // Generate pin and remove '012' from it
+    cmd.arg("50")
+        .arg("-d")
+        .arg("-r")
+        .arg("012")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"^[3-9\s]+$").unwrap());
 }


### PR DESCRIPTION
Unifies the generation pipeline by routing both standard passwords and numeric PINs (-d) through a single filtered generator. This ensures that exclusions (-r) and ambiguity flags (-B) are respected globally.

- Removed `generate_pin` in favor of a unified `generate_secure_password`.
- Updated `generate_secure_password` to accept a `digit_only` toggle.
- Updated unit tests to match new function signatures.
- Add intergration test for `-d` and exclusion `-r` flags.