### PR TITLE
fix: remove expect() panic path in password generation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ fn generate_secure_password(
     let remaining = len.saturating_sub(password.len());
     password.extend(
         (0..remaining)
-            .map(|_| *all_chars.choose(rng).expect("Pool is empty") as char),
+            .filter_map(|_| all_chars.choose(rng).map(|c| *c as char)),
     );
 
     password.shuffle(rng);


### PR DESCRIPTION
Replace .expect("Pool is empty") with .filter_map() + .map() to avoid an unreachable panic path. The pool is guaranteed non-empty by the early return guard, but the compiler cannot prove it.

Using filter_map gracefully handles the impossible None case by skipping it instead of panicking, which is safer and satisfies clippy::unwrap_used if enabled in the future.