### PR TITLE
fix: remove unused std::char import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use clap::Parser;
 use rand::Rng;
 use rand::prelude::IndexedRandom;
 use rand::seq::SliceRandom;
-use std::char;
 use std::process::ExitCode;
 
 #[derive(Parser)]


### PR DESCRIPTION
char is already in the prelude, this import is dead code.