### PR TITLE
fix: use copied() instead of cloned() for u8 dereference

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ fn get_pool(base: &[u8], avoid: bool, custom_exclude: Option<&str>) -> Vec<u8> {
             }
             true
         })
-        .cloned()
+        .copied()
         .collect()
 }
 


### PR DESCRIPTION
.copied() is semantically correct for Copy types like u8, whereas .cloned() is intended for Clone types that are not Copy.