### PR TITLE
fix: simplify main() signature by removing unused ExitCode return

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use clap::Parser;
 use rand::Rng;
 use rand::prelude::IndexedRandom;
 use rand::seq::SliceRandom;
-use std::process::ExitCode;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -36,7 +35,7 @@ const DIGITS: &[u8] = b"0123456789";
 const SPECIAL: &[u8] = b")-(*&^%$#@!~";
 const AMBIGUOUS: &[u8] = b"O0Il1";
 
-fn main() -> ExitCode {
+fn main() {
     let args = Cli::parse();
     let mut rng = rand::rng();
 
@@ -110,8 +109,6 @@ fn main() -> ExitCode {
     if num_cols > 1 && num_to_generate % num_cols as u16 != 0 {
         println!();
     }
-
-    ExitCode::SUCCESS
 }
 
 /// Helper to filter out ambiguous characters if requested


### PR DESCRIPTION
main() always returned ExitCode::SUCCESS with no error path, making the ExitCode return type and import unnecessary overhead.