### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,3 +13,8 @@ permissions:
 jobs:
   release:
     uses: riccione/github-workflows/.github/workflows/rust-release.yml@24ba5409c1eeac121965cedc2fb507b0387f25af
+    permissions:
+      contents: write
+    with:
+      bin_name: signum
+      tag: ${{ github.ref_name }}


### PR DESCRIPTION
Release worflow missed bin_name and tag.